### PR TITLE
Encode unicode object before hashing

### DIFF
--- a/web/services/views.py
+++ b/web/services/views.py
@@ -30,7 +30,7 @@ def createLocation(request):
     # or you won't be able to add the test value more than once.
     if ip_addr is None or ip_addr == LOCALHOST_IP:
         return None
-    ip_hash = hashlib.md5(ip_addr).hexdigest()
+    ip_hash = hashlib.md5(ip_addr.encode('utf-8')).hexdigest()
     if len(Location.objects.all().filter(ip=ip_hash)) == 0:
         # check for the HASHED ip in the database. If it isn't present,
         # create a new entry with the NON-HASHED ip as an argument.


### PR DESCRIPTION
On the server the reporter was producing an internal server error for each request:

```Internal Server Error: /api/usage
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.6/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/viewsets.py", line 114, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 505, in dispatch
    response = self.handle_exception(exc)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 465, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 476, in raise_uncaught_exception
    raise exc
  File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 502, in dispatch
    response = handler(request, *args, **kwargs)
  File "/usr/src/app/services/views.py", line 105, in create
    ip_hash = createLocation(request)
  File "/usr/src/app/services/views.py", line 33, in createLocation
    ip_hash = hashlib.md5(ip_addr).hexdigest()
```

Fixes the issue by encoding the `str` as a utf-8 bytestring before hashing.