### PR TITLE
Always enable loggers

### DIFF
--- a/web/settings.py
+++ b/web/settings.py
@@ -125,18 +125,22 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 # Logging
 if DEBUG:
-    LOGGING = {
-        'version': 1,
-        'disable_existing_loggers': False,
-        'handlers': {
-            'console': {
-                'class': 'logging.StreamHandler',
-            },
+  DEFAULT_LOG_LEVEL = 'DEBUG'
+else:
+  DEFAULT_LOG_LEVEL = 'ERROR'
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
         },
-        'loggers': {
-            'django': {
-                'handlers': ['console'],
-                'level': os.getenv('DJANGO_LOG_LEVEL', 'DEBUG'),
-            },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', DEFAULT_LOG_LEVEL),
         },
-    }
+    },
+}


### PR DESCRIPTION
Currently the loggers are only enabled for DEBUG so in production we miss all of the ERROR logs. This enables the console logger by default but switches the level between DEBUG/ERROR depending on the environment.