### PR TITLE
Swap volumes for mounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,7 @@ test/
 wsgi/static/admin/
 wsgi/static/report/
 wsgi/openshift/db.sqlite3
+
 .env
+pgdata
+webdata

--- a/bin/boot.sh
+++ b/bin/boot.sh
@@ -1,9 +1,5 @@
-#! /bin/bash
+#! /bin/bash -e
 # Starts the stack
-
-function mk_django_secret() {
-  python3 -c "import random,string;print('%s'%''.join([random.SystemRandom().choice(\"{}{}{}\".format(string.ascii_letters, string.digits, string.punctuation)) for i in range(63)]))";
-}
 
 function create_external_net(){
   network_name=nginx_net
@@ -13,51 +9,16 @@ function create_external_net(){
 
 SCRIPTPATH=$(cd "$(dirname "$0")"; pwd -P)
 SOURCE_DIR=$(cd "$SCRIPTPATH" && cd .. && pwd -P)
-PROJECT_NAME=reports
-DB_VOLUME_NAME=${PROJECT_NAME}_pgdata
+PROJECT_NAME=errorreports
 
-# Required by django settings
-DB_SERVICE=postgres
-DB_PORT=5432
-# Create a secret key
-SECRET_KEY=$(mk_django_secret)
-export DB_SERVICE DB_PORT SECRET_KEY
-
-# Does the database volume already exist
-_volume=$(docker volume ls | grep -E "\s+$DB_VOLUME_NAME")
-if [ $# -eq 1 ]; then
-  if [ -n "${_volume}" ]; then
-    echo "Initial database dump supplied but database volume already exists. Please remove the volume to continue."
-    exit 1
-  fi
-  if [ ! -f "$1" ]; then
-    echo "SQL dump \"$1\" does not exist"
-    exit 1
-  fi
-  DB_DUMP=$1
-  if [ "${DB_DUMP:0:1}" != "/" ]; then
-      DB_DUMP=$PWD/$DB_DUMP
-  fi
-  export DB_DUMP
-  COMPOSE_FILES="--file ${SOURCE_DIR}/docker-compose.yml --file ${SOURCE_DIR}/docker-compose-db-import.yml"
-  echo "Using provided database dump to populate database."
-elif [ $# -eq 0 ]; then
-  if [ -n "${_volume}" ]; then
-    echo "Using existing database volume."
-  else
-    echo "Starting with clean database."
-  fi
-  COMPOSE_FILES="--file ${SOURCE_DIR}/docker-compose.yml"
-else
-  echo "Usage: $0 [path-postrges-sql-dump]"
+if [[ ! -f "$SOURCE_DIR/.env" ]]; then
+  echo "Please copy and configure the .env file from blank.env"
   exit 1
 fi
 
-if [ ! -f ${SOURCE_DIR}/.env ]; then
-  echo "Unable to find environment file ${SOURCE_DIR}/.env. It must contain the following variables:"
-  echo "  DB_NAME, DB_USER, DB_PASS"
-  exit 1
-fi
+# Create empty directories, so they are not owned by root
+mkdir -p "$SOURCE_DIR/pgdata"
+mkdir -p "$SOURCE_DIR/webdata"
 
 # Start external network
 create_external_net

--- a/bin/boot.sh
+++ b/bin/boot.sh
@@ -9,7 +9,7 @@ function create_external_net(){
 
 SCRIPTPATH=$(cd "$(dirname "$0")"; pwd -P)
 SOURCE_DIR=$(cd "$SCRIPTPATH" && cd .. && pwd -P)
-PROJECT_NAME=errorreports
+PROJECT_NAME=usage_reports
 
 if [[ ! -f "$SOURCE_DIR/.env" ]]; then
   echo "Please copy and configure the .env file from blank.env"

--- a/bin/boot.sh
+++ b/bin/boot.sh
@@ -9,7 +9,7 @@ function create_external_net(){
 
 SCRIPTPATH=$(cd "$(dirname "$0")"; pwd -P)
 SOURCE_DIR=$(cd "$SCRIPTPATH" && cd .. && pwd -P)
-PROJECT_NAME=usage_reports
+PROJECT_NAME=reports
 
 if [[ ! -f "$SOURCE_DIR/.env" ]]; then
   echo "Please copy and configure the .env file from blank.env"

--- a/bin/shutdown.sh
+++ b/bin/shutdown.sh
@@ -8,8 +8,11 @@ PROJECT_NAME=reports
 
 cd ${SOURCE_DIR}
 docker-compose down
-# The webdata should not really be a volume as all of the files come out of the image
-# We remove it so the next rebuild sees the most recent version of the Python code
-docker volume rm ${PROJECT_NAME}_webdata
+
+# the web data volume shouldn't really be persistent as all of the files
+# come from an image
+echo "Removing webdata volume so it is rebuilt on next startup"
+rm -r "${SOURCE_DIR}/webdata"
+
 echo "Removing external network nginx_net"
 docker network rm nginx_net

--- a/blank.env
+++ b/blank.env
@@ -1,0 +1,13 @@
+# Default config
+DB_NAME=django
+
+# Generate with pwgen -s 32 1
+SECRET_KEY=<Not Set>
+
+# These are located in the password management tool
+DB_USER=<Not Set>
+DB_PASS=<Not Set>
+
+DB_SERVICE=postgres
+DB_PORT=5432
+HOST_PORT=8082

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
   web:
     restart: always
     build: ./web
+    volumes:
+      - webdata:/usr/src/app
     expose:
       # Change the value in the nginx configuration if this is changed
       - "8000"
@@ -46,10 +48,14 @@ services:
     ports:
       - "${HOST_PORT}:80"
     volumes:
-      - ./webdata:/usr/src/app
+      - webdata:/usr/src/app
     networks:
       - default
       - nginx_net
+
+volumes:
+  # This allows Nginx to serve static content, as Django won't...
+  webdata:
 
 networks:
   nginx_net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,19 +2,17 @@ version: '3.2'
 services:
   postgres:
     image: postgres:11.5
-# Uncomment this line and update to enable different configuration settings
-#    command: postgres -c log_min_duration_statement=0
     restart: always
     volumes:
-      - pgdata:/var/lib/postgresql/data/
+      - ./pgdata:/var/lib/postgresql/data/
     env_file: .env
     environment:
-      - POSTGRES_USER=${DB_USER}
-      - POSTGRES_PASSWORD=${DB_PASS}
-      - POSTGRES_DB=${DB_NAME}
-      - DB_SERVICE
-      - DB_PORT
-      - SECRET_KEY
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASS}
+      POSTGRES_DB: ${DB_NAME}
+      DB_SERVICE: ${DB_SERVICE}
+      DB_PORT: ${DB_PORT}
+      SECRET_KEY: ${SECRET_KEY}
 
   adminer:
     image: adminer
@@ -28,8 +26,6 @@ services:
   web:
     restart: always
     build: ./web
-    volumes:
-      - webdata:/usr/src/app
     expose:
       # Change the value in the nginx configuration if this is changed
       - "8000"
@@ -37,11 +33,11 @@ services:
       - postgres
     env_file: .env
     environment:
-      - DB_SERVICE
-      - DB_PORT
-      - SECRET_KEY
-      # Define this in .env for development mode. DO NOT USED IN PRODUCTION
-      - DEBUG
+      DB_SERVICE: ${DB_SERVICE}
+      DB_PORT: ${DB_PORT}
+      SECRET_KEY: ${SECRET_KEY}
+      # Define this in .env for development mode. DO NOT USE IN PRODUCTION
+      DEBUG: ${DEBUG}
 
   nginx-reports:
     restart: always
@@ -50,15 +46,10 @@ services:
     ports:
       - "${HOST_PORT}:80"
     volumes:
-      - webdata:/usr/src/app
+      - ./webdata:/usr/src/app
     networks:
       - default
       - nginx_net
-
-volumes:
-  webdata:
-  # If this is changed remember to update the bin/boot.sh script
-  pgdata:
 
 networks:
   nginx_net:

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,8 +1,8 @@
-Django==2.2.24
-djangorestframework==3.11.2
-django-filter==2.2.0
+Django==3.2.11
+djangorestframework==3.13.1
+django-filter==2.4.0
 Markdown
-requests==2.23.0
+requests
 plotly
 gunicorn
 gevent


### PR DESCRIPTION
This gives us a number of benefits
- Makes backing up the image trivial compared to docker vols
- Devs can easily delete / modify /inspect webdata
- docker-compose up "just works"

To test:

- Run bin/boot.sh
- Run bin/shutdown.sh
- Try running docker-compose up after bin/boot.sh (this will create nginx_net which is required)
