### PR TITLE
Add backup/restore scripts for database

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Takes a backup of the error reporter DB in the current dir
+if [[ -z "$1" ]]; then
+    >&2 echo "The name of the file to backup is required"
+    exit 1
+fi
+
+
+SCRIPTPATH=$(cd "$(dirname "$0")"; pwd -P)
+SOURCE_DIR=$(cd "$SCRIPTPATH" && cd .. && pwd -P)
+
+source ${SOURCE_DIR}/.env
+
+PROJECT_NAME=reports
+PG_DOCKER_NAME=$PROJECT_NAME"_postgres_1"
+
+docker exec -t $PG_DOCKER_NAME pg_dumpall -c -U ${DB_USER} | gzip > $1

--- a/bin/restore.sh
+++ b/bin/restore.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Restores a backup of the error reporter DB in the current dir
+if [[ -z "$1" ]]; then
+    >&2 echo "The name of the file to restore is required"
+    exit 1
+fi
+
+SCRIPTPATH=$(cd "$(dirname "$0")"; pwd -P)
+SOURCE_DIR=$(cd "$SCRIPTPATH" && cd .. && pwd -P)
+
+source ${SOURCE_DIR}/.env
+
+PROJECT_NAME=reports
+PG_DOCKER_NAME=$PROJECT_NAME"_postgres_1"
+
+# sed - Removes an in-line comment to drop and restore the current user, which won't work as we are using that login to actually restore
+
+# Use template1 (which will also exist for a new db) as the target, as psql needs a target DB even for a full restore
+gunzip -c $1 | sed "/^DROP ROLE.*${DB_USER}/d;/^CREATE ROLE.*${DB_USER}/d" | docker exec -i $PG_DOCKER_NAME psql -U ${DB_USER} template1
+
+echo "Please restart the stack to ensure ORM picks up changes"


### PR DESCRIPTION
Adds scripts to easily export and import the database. Restore is particularly useful to test a local copy with a copy of the production database.