### PR TITLE
Use Docker volume on macOS/Windows

### DIFF
--- a/bin/boot.sh
+++ b/bin/boot.sh
@@ -16,13 +16,18 @@ if [[ ! -f "$SOURCE_DIR/.env" ]]; then
   exit 1
 fi
 
-# Create empty directories, so they are not owned by root
-mkdir -p "$SOURCE_DIR/pgdata"
-mkdir -p "$SOURCE_DIR/webdata"
+COMPOSE_ARGS="--file ${SOURCE_DIR}/docker-compose.yml"
+if [[ $OSTYPE == "msys"* ]] || [[ $OSTYPE == 'darwin'* ]]; then
+  # Use volume mounts to avoid permission issues
+  COMPOSE_ARGS="${COMPOSE_ARGS} --file ${SOURCE_DIR}/docker-compose-use-docker-volume.yml"
+else
+  # Create empty directories, so they are not owned by root
+  mkdir -p "${SOURCE_DIR}/pgdata"
+fi
 
 # Start external network
 create_external_net
 # Build services
-docker-compose ${COMPOSE_FILES} --project-name ${PROJECT_NAME} build
+docker-compose ${COMPOSE_ARGS} --project-name ${PROJECT_NAME} build
 # Bring up the stack and detach
-docker-compose ${COMPOSE_FILES} --project-name ${PROJECT_NAME} up -d
+docker-compose ${COMPOSE_ARGS} --project-name ${PROJECT_NAME} up -d

--- a/bin/shutdown.sh
+++ b/bin/shutdown.sh
@@ -12,7 +12,7 @@ docker-compose down
 # the web data volume shouldn't really be persistent as all of the files
 # come from an image
 echo "Removing webdata volume so it is rebuilt on next startup"
-rm -r "${SOURCE_DIR}/webdata"
+docker volume rm "${PROJECT_NAME}_webdata"
 
 echo "Removing external network nginx_net"
 docker network rm nginx_net

--- a/docker-compose-use-docker-volume.yml
+++ b/docker-compose-use-docker-volume.yml
@@ -1,0 +1,17 @@
+# Override file to use a named Docker volume over a bind mount
+# Bind mounts can be tricky on macos/Windows with permissions
+# and are not required for development. Use this file
+# to specify a named volume mount instead
+#
+# These overrides are intended to be used for development
+# and the main compose file should work standalone using
+# a standard "docker-compose up"
+
+version: '3.2'
+services:
+  postgres:
+    volumes:
+      - pgdata:/var/lib/postgresql/data/
+
+volumes:
+  pgdata:


### PR DESCRIPTION
Bind mounts seem problematic on macOS/Windows due to permission issues in the VM. For development
a docker volume is sufficient.

The standard compose setup is left unchanged so that a `docker-compose up` will still work as expected.