### PR TITLE
Updated Python version to 3.10

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-jessie
+FROM python:3.10
 
 # Install app
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
The image has long been based on Python 3.6 and the Debian Jessie distro.

This change switches to the latest stable version of Python: 3.10. It also switches away from hardcoding the version of Debian that for us is not relevant. We deliberately pin only to the major.minor version so we can receive the latest version of Python patches by just running an image build. 

**To test:**

* Checkout the branch locally
* Run the server
* Point Mantid at it and check it posts a report

