### PR TITLE
Create .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Django startup file must have LF line endings or the container will not start
+web/**      text eol=lf


### PR DESCRIPTION
Add gitattributes for EOL conversion of web app.
This will always be run in a Linux container so expects
LF line endings.

Without these changes the web container won't start on Windows.

**To test**:

I am not 100% certain if git wil immediately respect the attributes if they didn't exist previously. When checking out
this branch on Windows open a file in the `web` directory in any editor like Notepad++ or VSCode and see it has LF line endings.
Check the container starts.