### PR TITLE
Adding timestamp to feature use model

### DIFF
--- a/web/services/models.py
+++ b/web/services/models.py
@@ -87,6 +87,7 @@ class FeatureUsage(models.Model):
     internal = models.BooleanField(default=False)    # ex: "False"
     count = models.BigIntegerField()        # ex: "3"
     mantidVersion = models.CharField(max_length=32)  # ex: "3.2.20141208.1820"
+    timestamp = models.DateTimeField(auto_now_add=True)
     application = models.CharField(max_length=32)
 
     class Meta:

--- a/web/services/serializer.py
+++ b/web/services/serializer.py
@@ -36,7 +36,7 @@ class FeatureSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = FeatureUsage
-        fields = ['url', 'type', 'name', 'internal', 'count', 'mantidVersion', 'application']
+        fields = ['url', 'type', 'name', 'internal', 'count', 'mantidVersion', 'timestamp', 'application']
 
     def checkLength(self, value, length, label):
         if (len(value) != length):


### PR DESCRIPTION
This PR will add a timestamp to the feature use model.

The goal is to be able to separate out feature usages by time.

Because feature use seems to be an aggregate, I'm unsure of exactly how this will work.

This is a work in progress, and requires more experimentation to ensure correct behavior.