### PR TITLE
Upgrade Django version to v4.1 for the reports service

### DIFF
--- a/DevelopmentSetup.md
+++ b/DevelopmentSetup.md
@@ -140,8 +140,9 @@ such as
 * the port to run on
 * the name of the database user
 * the database password
+* the trusted CSRF origin URLs as appropriate. For developer testing set either http://localhost:8082 or https://reports.a.staging-mantidproject.stfc.ac.uk if testing on staging environment. But for the production usage only set this to https://reports.mantidproject.org
 
-in order to function correctly. Docker compose supports the de-facto standard
+In order to function correctly. Docker compose supports the de-facto standard
 method for setting initial environment variables: `.env files`.
 If a file called `.env` is present in the same directory as `docker-compose.yml`
 then this file is sourced and the variables contained within are exported to the
@@ -191,6 +192,19 @@ and enter the requested details. Once the account has been created go to
 
 If this step fails then see the section below on Shutdown the Server and remove postgres volume.
 
+## Adminer database management account
+
+To access the `Adminer` database management tool, access the below URL from your web browser `http://localhost:<HOST_PORT>/adminer` and use the `DB_USER` and `DB_PASS` configured in the `.env` file as the credentials. 
+
+If you prefer using the command line to access the postgres database from inside the docker container first enter into the docker container in the interactive mode as below. 
+```sh
+docker exec -it <container_name_or_id> bash
+```
+Then log into the postgres database using psql CLI tool as below
+```sh
+psql -U $DB_USER -d $DB_NAME
+```
+
 ## Shutdown the Server and remove postgres volume
 
 When finished with the server, from the root of your source directory, you can shut it down:
@@ -213,3 +227,5 @@ error message to help you debug the problem.
 
 An error about invalid credentials could be caused by persisting data from a previous
 time you have looked at this repo. To clear any persisting data, run the shutdown script.
+
+It is always recommended to check the logs of the started docker containers to observe any startup errors by running `docker logs <container_name_or_id>`

--- a/blank.env
+++ b/blank.env
@@ -17,3 +17,7 @@ DB_PORT=5432
 SECRET_KEY=<Not Set>
 DB_USER=<Not Set>
 DB_PASS=<Not Set>
+
+
+#Trusted origins for CSRF validation. For production usage only specify https://reports.mantidproject.org
+DJANGO_CSRF_TRUSTED_ORIGINS=http://localhost:8082,https://reports.a.staging-mantidproject.stfc.ac.uk

--- a/blank.env
+++ b/blank.env
@@ -18,6 +18,5 @@ SECRET_KEY=<Not Set>
 DB_USER=<Not Set>
 DB_PASS=<Not Set>
 
-
 #Trusted origins for CSRF validation. For production usage only specify https://reports.mantidproject.org
 DJANGO_CSRF_TRUSTED_ORIGINS=http://localhost:8082,https://reports.a.staging-mantidproject.stfc.ac.uk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,12 +43,13 @@ services:
 
   nginx-reports:
     restart: always
-    build: ./nginx/
+    image: bitnami/nginx
     env_file: .env
     ports:
       - "${HOST_PORT}:80"
     volumes:
       - webdata:/usr/src/app
+      - "./nginx/confs/mantidreports.conf:/opt/bitnami/nginx/conf/server_blocks/mantidreports.conf:ro"
     networks:
       - default
       - nginx_net

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,3 +1,0 @@
-FROM tutum/nginx
-RUN rm /etc/nginx/sites-enabled/default
-ADD sites-enabled/ /etc/nginx/sites-enabled

--- a/nginx/confs/mantidreports.conf
+++ b/nginx/confs/mantidreports.conf
@@ -20,8 +20,11 @@ server {
     }
 
     location / {
-        include proxy_params;
         proxy_pass http://web:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
 
         # Some operations can take a while so make sure the gateway doesn't timeout with a 502
         proxy_connect_timeout      60s;

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -7,6 +7,8 @@ COPY requirements.txt /usr/src/app/
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . /usr/src/app
 
+#this is a test line
+
 # Startup script
 COPY run_django.sh /usr/local/bin/
 CMD ["run_django.sh"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -7,8 +7,6 @@ COPY requirements.txt /usr/src/app/
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . /usr/src/app
 
-#this is a test line
-
 # Startup script
 COPY run_django.sh /usr/local/bin/
 CMD ["run_django.sh"]

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,6 +1,6 @@
-Django==3.2.25
-djangorestframework==3.13.1
-django-filter==2.4.0
+Django==4.1
+djangorestframework
+django-filter
 Markdown
 requests
 plotly

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,6 +1,6 @@
 Django==4.1
-djangorestframework
-django-filter
+djangorestframework==3.15.1
+django-filter==23.5
 Markdown
 requests
 plotly

--- a/web/services/urls.py
+++ b/web/services/urls.py
@@ -1,4 +1,3 @@
-from django.conf.urls import include, url
 from django.urls import path
 
 from rest_framework import routers

--- a/web/settings.py
+++ b/web/settings.py
@@ -141,8 +141,4 @@ if DEBUG:
 APPEND_SLASH=True
 
 #CSRF validation settings
-CSRF_TRUSTED_ORIGINS = [
-    'https://reports.mantidproject.org',
-    'http://localhost:8083',
-    'https://reports.a.staging-mantidproject.stfc.ac.uk'
-    ]
+CSRF_TRUSTED_ORIGINS = os.getenv("DJANGO_CSRF_TRUSTED_ORIGINS", "").split(",")

--- a/web/settings.py
+++ b/web/settings.py
@@ -139,3 +139,10 @@ if DEBUG:
     }
 
 APPEND_SLASH=True
+
+#CSRF validation settings
+CSRF_TRUSTED_ORIGINS = [
+    'https://reports.mantidproject.org',
+    'http://localhost:8083',
+    'https://reports.a.staging-mantidproject.stfc.ac.uk'
+    ]

--- a/web/urls.py
+++ b/web/urls.py
@@ -1,13 +1,11 @@
-from django.conf.urls import include, url
-from django.urls import path
-
+from django.urls import include, path
 from django.contrib import admin
-admin.autodiscover()
-
 from django.views.generic.base import RedirectView
 
 import report
 import services
+
+admin.autodiscover()
 
 urlpatterns = [
     path('admin/', admin.site.urls),


### PR DESCRIPTION
This pull request captures all the changes made from the `reports` repository to upgrade its `Django` version to v4.1 and to upgrade the production `reports` service to the latest changes from the main branch.

This work captures the required changes for updating the previously used `tutum/nginx` Docker image to `bitnami/nginx` as well for `nginx-reports` service.

During testing, it was identified that the [suggested changes](https://github.com/mantidproject/reports/pull/70) from the Dependabot are not compatible and hence that pull request will be closed.

