### PR TITLE
Updraded Django version to support postgres v13

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,6 +1,6 @@
-Django==4.1
-djangorestframework==3.15.1
-django-filter==23.5
+Django==5.0
+djangorestframework==3.16.0
+django-filter==25.1
 Markdown
 requests
 plotly


### PR DESCRIPTION
This pull request is created to address the security vulnerabilities raised by this [dependabot PR](https://github.com/mantidproject/reports/pull/76). 

The original suggestions from dependabot were not compatible with the existing postgres version 11.5. And hence a [separate PR](https://github.com/mantidproject/ansible-linode/pull/143) was raised to upgrade the DB via ansible-linode.