### PR TITLE
Upgrade Django version to v5.1.10

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,5 +1,5 @@
-Django==5.0
-djangorestframework==3.16.0
+Django==5.1.10
+djangorestframework==3.16.1
 django-filter==25.1
 Markdown
 requests


### PR DESCRIPTION
This PR was made to address the reported security issues with the current Django version of 4.1 and to upgrade it to [Django version 5.1.10](https://docs.djangoproject.com/en/5.2/releases/5.1.10/). The upgrade has already been applied to the production server.

Closes #80 
